### PR TITLE
Fix README link formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ branchProtection:
     required_pull_request_reviews: null
     restrictions: null
 repo:
-  # see octokit docs for all paramshttps://octokit.github.io/rest.js/v18#repos-update
+  # see octokit docs for all params:
+  # https://octokit.github.io/rest.js/v18#repos-update
   has_issues: true
   has_projects: false
   has_wiki: false


### PR DESCRIPTION
## Summary
- fix docs link formatting so the octokit URL renders correctly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68401e8aab4c832aa6a0743da9e294cc