### PR TITLE
Add owner config only test

### DIFF
--- a/__tests__/__snapshots__/test.js.snap
+++ b/__tests__/__snapshots__/test.js.snap
@@ -1,5 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`#getRepoConfig() should merge the base config with the owner config when the repo lacks config 1`] = `
+{
+  "another": "bar",
+  "bar": "foo",
+}
+`;
+
 exports[`#getRepoConfig() should override the base config with the owner then the repo 1`] = `
 {
   "another": "bar",

--- a/__tests__/test.js
+++ b/__tests__/test.js
@@ -27,4 +27,21 @@ describe('#getRepoConfig()', () => {
       mod.getRepoConfig('foo', 'bar', octomock)
     ).resolves.toMatchSnapshot()
   })
+
+  it('should merge the base config with the owner config when the repo lacks config', () => {
+    const configFromOwner = 'another: bar'
+    const octomock = {
+      repos: {
+        getContent: jest
+          .fn()
+          .mockRejectedValueOnce(new Error('no repo config'))
+          .mockResolvedValueOnce({
+            data: { content: Buffer.from(configFromOwner).toString('base64') }
+          })
+      }
+    }
+    return expect(
+      mod.getRepoConfig('foo', 'bar', octomock)
+    ).resolves.toMatchSnapshot()
+  })
 })


### PR DESCRIPTION
## Summary
- extend tests to cover owner-only repo config scenario
- update snapshots

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68401e898d2c832abc10ef686028cf7b