### PR TITLE
Stop bot looping on its own consent-issue edits

### DIFF
--- a/__tests__/handler.test.js
+++ b/__tests__/handler.test.js
@@ -164,6 +164,30 @@ describe('applyConsentedChanges', () => {
     expect(result.applied).toBe(0)
   })
 
+  it('skips items that are already struck through (applied)', async () => {
+    const octokit = createMockOctokit()
+    const repoYaml = [
+      'branchProtection:',
+      "  - branch: '__DEFAULT_BRANCH__'",
+      '    required_linear_history: true',
+    ].join('\n')
+    octokit.rest.repos.getContent
+      .mockRejectedValueOnce(Object.assign(new Error('nf'), { status: 404 }))
+      .mockResolvedValueOnce({ data: { content: base64(repoYaml) } })
+    const issueBody = `- [x] <!-- repomanager:${encodeId('bp:main')} --> ~~Apply BP~~`
+    const result = await applyConsentedChanges(octokit, makeRepo(), { number: 9, body: issueBody })
+    expect(result.applied).toBe(0)
+    expect(octokit.rest.repos.updateBranchProtection).not.toHaveBeenCalled()
+  })
+
+  it('skips items in failed (⚠️) state', async () => {
+    const octokit = createMockOctokit()
+    const issueBody = `- [ ] <!-- repomanager:${encodeId('bp:main')} --> ⚠️ Apply BP`
+    const result = await applyConsentedChanges(octokit, makeRepo(), { number: 9, body: issueBody })
+    expect(result.applied).toBe(0)
+    expect(octokit.rest.repos.updateBranchProtection).not.toHaveBeenCalled()
+  })
+
   it('posts a sanitised comment when an apply fails and unticks the box', async () => {
     const octokit = createMockOctokit()
     const repoYaml = [
@@ -344,6 +368,31 @@ describe('webhook entry', () => {
     } finally {
       mockedOctokitModule.__webhooks.verifyAndReceive = original
     }
+  })
+
+  it('ignores issues.edited events triggered by the bot itself', async () => {
+    const octokit = createMockOctokit()
+    mockedOctokitModule.__state.octokit = octokit
+    await webhook({
+      headers: {
+        'x-hub-signature-256': 'sha256=ignored',
+        'x-github-delivery': 'd-self',
+        'x-github-event': 'issues',
+      },
+      body: JSON.stringify({
+        action: 'edited',
+        sender: { login: 'the-repository-manager[bot]', type: 'Bot' },
+        issue: {
+          number: 9,
+          title: 'repomanager: changes awaiting approval',
+          body: `- [x] <!-- repomanager:${encodeId('bp:main')} --> Apply BP`,
+          labels: [{ name: 'repomanager:consent' }],
+        },
+        repository: makeRepo(),
+      }),
+    })
+    expect(octokit.rest.repos.updateBranchProtection).not.toHaveBeenCalled()
+    expect(octokit.rest.issues.update).not.toHaveBeenCalled()
   })
 
   it('handles issues.edited consent events through the webhook dispatcher', async () => {

--- a/handler.js
+++ b/handler.js
@@ -4,7 +4,7 @@ const { planRepo, splitByRisk } = require('./src/planner')
 const { applyChanges } = require('./src/applier')
 const {
   upsertConsentIssue,
-  parseCheckedItems,
+  parseAllItems,
   markItemsApplied,
   postFailureComment,
   openInvalidConfigIssue,
@@ -144,8 +144,14 @@ const cronDispatcher = async () => {
 }
 
 const applyConsentedChanges = async (octokit, repo, issue) => {
-  const checkedIds = parseCheckedItems(issue.body)
-  if (!checkedIds.size) return { applied: 0 }
+  // Only apply items the user has ticked AND we haven't already applied or
+  // marked as failed. Re-applying struck-through items would re-run idempotent
+  // calls for nothing (and breaks for non-idempotent ones like createPullRequest).
+  const items = parseAllItems(issue.body)
+  const targetIds = new Set(
+    items.filter((i) => i.checked && !i.applied && !i.failed).map((i) => i.id),
+  )
+  if (!targetIds.size) return { applied: 0 }
 
   const { config, errors } = await getRepoConfig(repo.name, repo.owner.login, octokit)
   if (errors) {
@@ -153,7 +159,7 @@ const applyConsentedChanges = async (octokit, repo, issue) => {
     return { applied: 0 }
   }
   const changes = await planRepo(octokit, repo, config)
-  const toApply = changes.filter((c) => checkedIds.has(c.id))
+  const toApply = changes.filter((c) => targetIds.has(c.id))
   if (!toApply.length) return { applied: 0 }
 
   const results = await applyChanges(octokit, repo, toApply, { dryRun: isDryRun() })
@@ -191,6 +197,12 @@ const handleIssuesEdited = async (octokit, payload) => {
   if (issue.title !== ISSUE_TITLE) return
   const labels = (issue.labels || []).map((l) => (typeof l === 'string' ? l : l.name))
   if (!labels.includes(CONSENT_LABEL)) return
+  // Ignore edits we made ourselves (markItemsApplied / upsertConsentIssue).
+  // Otherwise every body update fans out into another applyConsentedChanges
+  // pass, re-running already-done apply calls (and tripping idempotency
+  // failures like "PR already exists").
+  const sender = payload.sender || {}
+  if (sender.type === 'Bot' && /\[bot\]$/.test(sender.login || '')) return
   await applyConsentedChanges(octokit, payload.repository, issue)
 }
 

--- a/src/applier.js
+++ b/src/applier.js
@@ -77,12 +77,16 @@ const applyFiles = async (octokit, repo, files) => {
     )
     return { skipped: true }
   }
+  // update: true makes the call idempotent — if a PR with this head branch
+  // already exists (open from a previous apply) the plugin updates it in
+  // place rather than throwing "Pull request already exists".
   return octokit.createPullRequest({
     owner: repo.owner.login,
     repo: repo.name,
     title: 'Update templated files',
     body: '',
     createWhenEmpty: false,
+    update: true,
     head: headBranch,
     changes: [
       {


### PR DESCRIPTION
## Summary

- Ignore issues.edited events whose sender is a Bot, so the bot's own markItemsApplied/upsertConsentIssue body writes don't fan out into another applyConsentedChanges pass.
- applyConsentedChanges now only acts on items that are checked AND not already applied (struck) AND not in ⚠️ state.
- applyFiles passes update:true so retries against an existing open repomanager_files PR are no-ops rather than "Pull request already exists" errors.

Caught while bulk-ticking 30 chrisns consent issues — most started looping their own apply work and hit ⚠️ state on files:pr.

## Test plan

- [x] All 86 unit tests pass.
- [ ] Mergify auto-merges this once CI is green.
- [ ] Re-tick the ⚠️ consent issues across chrisns repos and verify they close cleanly.